### PR TITLE
Fix image linking issue

### DIFF
--- a/components/ActionCard/ActionCardAbout.js
+++ b/components/ActionCard/ActionCardAbout.js
@@ -3,14 +3,14 @@ import clsx from "clsx";
 
 import ActionCard, { ActionCardLabel, ActionCardTitle } from "./ActionCard";
 import Heading from "components/Heading/Heading";
-import Image, { computeImageProps } from "components/Image/Image";
+import Image, { computeImageProps, isValidImage } from "components/Image/Image";
 
 import styles from "./ActionCardAbout.module.scss";
 
 export function computeActionCardAboutProps(globalSettings) {
-  const photosProps = globalSettings.aboutCardPhotos.map((image) => {
-    return computeImageProps(image);
-  });
+  const photosProps = globalSettings.aboutCardPhotos
+    .filter((image) => isValidImage(image))
+    .map((image) => computeImageProps(image));
 
   return {
     heading: globalSettings.aboutCardTitle,

--- a/components/ActionCard/ActionCardProjects.js
+++ b/components/ActionCard/ActionCardProjects.js
@@ -2,14 +2,14 @@ import Link from "next/link";
 import clsx from "clsx";
 
 import ActionCard, { ActionCardLabel, ActionCardTitle } from "./ActionCard";
-import Image, { computeImageProps } from "components/Image/Image";
+import Image, { computeImageProps, isValidImage } from "components/Image/Image";
 
 import styles from "./ActionCardProjects.module.scss";
 
 export function computeActionCardProjectsProps(globalSettings) {
-  const rows = globalSettings.projectsCardImageRows.map((a) => {
-    return computeImageProps(a);
-  });
+  const rows = globalSettings.projectsCardImageRows
+    .filter((image) => isValidImage(image))
+    .map((image) => computeImageProps(image));
 
   return {
     heading: globalSettings.projectsCardTitle,

--- a/components/ArticleCard/ArticleCard.js
+++ b/components/ArticleCard/ArticleCard.js
@@ -4,7 +4,7 @@ import { computeTextColor } from "services/contentful";
 
 import ActionCard, { ActionCardTitle } from "components/ActionCard/ActionCard";
 import Heading from "components/Heading/Heading";
-import { computeImageProps } from "components/Image/Image";
+import { computeImageProps, isValidImage } from "components/Image/Image";
 
 import styles from "./ArticleCard.module.scss";
 
@@ -13,7 +13,7 @@ export function computeArticleCardProps({ fields }) {
 
   const textColor = computeTextColor(fields.textColor);
   const backgroundImageProps =
-    backgroundImage && computeImageProps(backgroundImage);
+    isValidImage(backgroundImage) && computeImageProps(backgroundImage);
 
   return {
     title,

--- a/components/Image/Image.js
+++ b/components/Image/Image.js
@@ -29,7 +29,9 @@ export function computeImageContentType(image) {
   }
 }
 
-export function computeImageProps(image, overrideWidth) {
+export const isValidImage = (image) => !!image?.fields?.file;
+
+export function computeImageProps(image, overrideWidth, debug = "") {
   const { url } = image.fields.file;
 
   let { height, width } = image.fields.file.details.image;

--- a/components/Meta/Title.js
+++ b/components/Meta/Title.js
@@ -3,12 +3,11 @@ import Head from "next/head";
 function Title({ shortTitle, longTitle = shortTitle, prefix = true }) {
   if (!shortTitle) return null;
 
+  const title = prefix ? `Kickpush | ${shortTitle}` : shortTitle;
+
   return (
     <Head>
-      <title key="title">
-        {prefix && "Kickpush | "}
-        {shortTitle}
-      </title>
+      <title key="title">{title}</title>
       <meta key="metaTitle" name="title" content={longTitle} />
       <meta key="ogTitle" property="og:title" content={longTitle} />
       <meta key="twitterTitle" property="twitter:title" content={longTitle} />

--- a/components/ProjectCard/ProjectCard.js
+++ b/components/ProjectCard/ProjectCard.js
@@ -8,14 +8,14 @@ import ActionCard, {
   ActionCardTitle,
 } from "components/ActionCard/ActionCard";
 import Heading from "components/Heading/Heading";
-import { computeImageProps } from "components/Image/Image";
+import { computeImageProps, isValidImage } from "components/Image/Image";
 
 import styles from "./ProjectCard.module.scss";
 
 export function computeProjectCardProps({ fields }, globalSettings) {
   const textColor = computeTextColor(fields.cardTextColor);
   const backgroundImageProps =
-    fields.cardImage && computeImageProps(fields.cardImage);
+    isValidImage(fields.cardImage) && computeImageProps(fields.cardImage);
 
   return {
     slug: fields.slug,

--- a/components/ProjectPage/ProjectSlideItem.js
+++ b/components/ProjectPage/ProjectSlideItem.js
@@ -3,7 +3,7 @@ import clsx from "clsx";
 
 import { computeObjectFit } from "services/contentful";
 
-import Image, { computeImageProps } from "components/Image/Image";
+import Image, { computeImageProps, isValidImage } from "components/Image/Image";
 import ProjectSlide from "./ProjectSlide";
 
 import styles from "./ProjectSlideItem.module.scss";
@@ -19,7 +19,7 @@ export function computeProjectSlideItemProps({ fields }) {
     mobileImagePosition,
   } = fields;
 
-  if (!desktopImage && !mobileImage) return null;
+  if (!isValidImage(desktopImage)) return null;
 
   const desktop = {
     ...computeImageProps(desktopImage, 2000),
@@ -27,7 +27,7 @@ export function computeProjectSlideItemProps({ fields }) {
     objectPosition: (desktopImagePosition || "Center Center").toLowerCase(),
   };
 
-  const mobile = mobileImage
+  const mobile = isValidImage(mobileImage)
     ? computeImageProps(mobileImage, 1000)
     : computeImageProps(desktopImage, 1600);
   mobile.objectFit = mobileImageFit

--- a/pages/about.js
+++ b/pages/about.js
@@ -11,7 +11,7 @@ import Card, { CardReveal, CardsWrapper } from "components/Card/Card";
 import Description from "components/Meta/Description";
 import Heading from "components/Heading/Heading";
 import Hero, { HeroTitle } from "components/Hero/Hero";
-import Image, { computeImageProps } from "components/Image/Image";
+import Image, { computeImageProps, isValidImage } from "components/Image/Image";
 import Footer, { computeFooterProps } from "components/Footer/Footer";
 import Nav, { computeNavProps } from "components/Nav/Nav";
 import Title from "components/Meta/Title";
@@ -34,8 +34,11 @@ export default function About({ pageFields, globalSettings }) {
     movingTitle,
     movingArticle,
     photosTitle,
-    photosGrid,
   } = pageFields;
+
+  const photosGrid = pageFields.photosGrid.filter((photo) =>
+    isValidImage(photo)
+  );
 
   const heroArticleProps = heroArticle && computeArticleCardProps(heroArticle);
   const vrArticleProps = vrArticle && computeArticleCardProps(vrArticle);

--- a/pages/articles/[articleId].js
+++ b/pages/articles/[articleId].js
@@ -25,7 +25,7 @@ import Title from "components/Meta/Title";
 import MetaImage, { computeMetaImageProps } from "components/Meta/MetaImage";
 import PrivacyPolicy from "components/PrivacyPolicy/PrivacyPolicy";
 import Paragraph from "components/Paragraph/Paragraph";
-import Image, { computeImageProps } from "components/Image/Image";
+import Image, { computeImageProps, isValidImage } from "components/Image/Image";
 
 import IconActionArrow from "assets/icons/21-action-arrow.svg";
 
@@ -119,6 +119,8 @@ export default function Article({ pageFields, globalSettings }) {
       ),
       [BLOCKS.EMBEDDED_ASSET]: (node) => {
         const asset = node.data.target;
+        if (!isValidImage(asset)) return null;
+
         const { file, description } = asset.fields;
         if (!file.contentType.startsWith("image/")) return null;
 


### PR DESCRIPTION
`image` wasn't empty which meant that the checks being made before assigning images were passing, but then throwing JS errors when looking for image attributes in `undefined` objects. Added an `isValidImage` function that wraps around `image` instances to ensure that they are valid, and also so they can be updated in the future.

Also fixed a warning about too many elements in `<title />`